### PR TITLE
Model Comparison Experiment

### DIFF
--- a/experiments/models/bedrock-llama370B.config.json
+++ b/experiments/models/bedrock-llama370B.config.json
@@ -1,0 +1,6 @@
+{
+    "provider" : "bedrock",
+    "name": "meta.llama3-70b-instruct-v1:0",
+    "region": "us-west-2",
+    "temperature": 0.3
+}

--- a/experiments/models/google-gemini15-flash.config.json
+++ b/experiments/models/google-gemini15-flash.config.json
@@ -1,0 +1,7 @@
+{
+    "provider" : "vertex",
+    "name": "gemini-1.5-flash",
+    "project_id": "vertex-gemini-424313",
+    "location": "europe-west4",
+    "temperature": 0.3
+}

--- a/experiments/models/groq-llama3_70B.config.json
+++ b/experiments/models/groq-llama3_70B.config.json
@@ -1,0 +1,6 @@
+{
+    "provider" : "groq",
+    "name": "llama3-groq-70b-8192-tool-use-preview",
+    "max_output_tokens": 2048,
+    "temperature": 0.3
+}

--- a/experiments/models/groq-mixtral.config.json
+++ b/experiments/models/groq-mixtral.config.json
@@ -1,0 +1,5 @@
+{
+    "provider" : "groq",
+    "name": "mixtral-8x7b-32768",
+    "temperature": 0.3
+}

--- a/experiments/models/openai-GPT35.config.json
+++ b/experiments/models/openai-GPT35.config.json
@@ -1,0 +1,5 @@
+{
+    "provider" : "openai",
+    "model": "gpt-4o-mini",
+    "temperature": 0.3
+}

--- a/experiments/use-cases/finance/creditcard.config.json
+++ b/experiments/use-cases/finance/creditcard.config.json
@@ -1,0 +1,10 @@
+{
+  "prompt": "You are a helpful customer service representative for a credit card company who helps answer customer questions about their past transactions and spending history. Today's date is January 18th, 2024. You provide precise answers and use functions to look up information. You DO NOT provide general answers and only give an answer after you retrieved all the data you need via functions. Only invoke one function at a time and wait for the results before invoking another function.When you have worked out your answer, you answer the user question in one of two ways: 1) in markdown syntax using tables where appropriate to show data or 2) by calling the data_visualization function to display the data in a suitable fashion. Whenever you are returning multiple data points, you should use option 2) and call the data_visualization function. You should only call the data_visualization function when you already have all the data to display.",
+  "apis": {
+    "type": "local",
+    "url": "local",
+    "use_case": "finance"
+  },
+  "context": ["customerid"],
+  "plot-function": "oneD"
+}

--- a/experiments/use-cases/finance/creditcard.tools.json
+++ b/experiments/use-cases/finance/creditcard.tools.json
@@ -1,0 +1,116 @@
+[
+  {
+    "type": "api",
+    "function": {
+      "name": "spending_by_category",
+      "description": "Returns the customer spending by category by week in decreasing order of time, i.e. showing the most recent week first, then the week before that and so forth.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "customerid": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "The number of spending records to return. Each week has 12 records - one for each spending category. To return the spending records for multiple weeks, multiple the number of weeks by 12. For example, to return spending records for 5 week, set the limit to 60."
+          }
+        },
+        "required": ["customerid"]
+      }
+    },
+    "context": ["customerid"],
+    "api": {
+      "query": "query SpendingByCategory($customerid: Int!, $limit:Int = 12) {\n  SpendingByCategory(customerid: $customerid, limit: $limit) {\n    timeWeek\n    category\n    spending\n  }\n}"
+    }
+  },
+  {
+    "type": "api",
+    "function": {
+      "name": "spending_by_day",
+      "description": "Returns the total customer spending by day for the specified time period ordered by time (most recent first). When a particular day does not have any spending, no record is returned for that day.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "customerid": {
+            "type": "integer"
+          },
+          "fromTime": {
+            "type": "string",
+            "description": "RFC-3339 compliant date time scalar. Returns spending from this time. Use the start of the day only, e.g. `2024-01-19T00:00:00-00:00`."
+          },
+          "toTime": {
+            "type": "string",
+            "description": "RFC-3339 compliant date time scalar. Returns spending up to this time. Use the start of the day only, e.g. `2024-01-19T00:00:00-00:00`."
+          }
+        },
+        "required": ["customerid","fromTime","toTime"]
+      }
+    },
+    "context": ["customerid"],
+    "api": {
+      "query": "query SpendingByDay($customerid:Int!, $fromTime: DateTime!, $toTime: DateTime!) {\n  SpendingByDay(customerid:$customerid, fromTime: $fromTime, toTime: $toTime) {\n    timeDay\n    spending\n  }\n}"
+    }
+  },
+  {
+    "type": "api",
+    "function": {
+      "name": "transactions",
+      "description": "Returns all credit card transactions within a specified time period ordered by time (most recent first).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "customerid": {
+            "type": "integer"
+          },
+          "fromTime": {
+            "type": "string",
+            "description": "RFC-3339 compliant date time scalar. Returns transactions after this time. Use the start of the day only, e.g. `2024-01-19T00:00:00-00:00`."
+          },
+          "toTime": {
+            "type": "string",
+            "description": "RFC-3339 compliant date time scalar. Returns transactions up to this time. Use the start of the day only, e.g. `2024-01-19T00:00:00-00:00`."
+          }
+        },
+        "required": ["customerid","fromTime","toTime"]
+      }
+    },
+    "context": ["customerid"],
+    "api": {
+      "query": "query GetTransactions($customerid:Int!, $fromTime: DateTime!, $toTime: DateTime!) {\n  Transactions(customerid:$customerid, fromTime: $fromTime, toTime: $toTime) {\n    time\n    cardNo\n    amount\n    merchantName\n    category\n  }\n}"
+    }
+  },
+  {
+    "type": "api",
+    "function": {
+      "name": "InternalSaveChatMessage",
+      "description": "Saves User Chat Messages",
+      "parameters": {
+        "type": "object",
+        "properties": {
+        },
+        "required": []
+      }
+    },
+    "context": ["customerid"],
+    "api": {
+      "query": "mutation AddChatMsg($role: String!, $content: String!, $name: String, $context: ChatMessageContextInput!) {\n  AddChatMessage(message: {role: $role, content:$content, name: $name, context:$context}) {\n    event_time\n  }\n}"
+    }
+  },
+  {
+    "type": "api",
+    "function": {
+      "name": "InternalGetChatMessages",
+      "description": "Retrieves User Chat Messages",
+      "parameters": {
+        "type": "object",
+        "properties": {
+        },
+        "required": []
+      }
+    },
+    "context": ["customerid"],
+    "api": {
+      "query": "query GetChatMessages($customerid: Int!, $limit: Int = 10) {\nmessages: CustomerChatMessage(customerid: $customerid, limit:$limit) {\n  role\n  content\n name\n}\n}"
+    }
+  }
+]

--- a/experiments/use-cases/finance/finance-agent.sessions.json
+++ b/experiments/use-cases/finance/finance-agent.sessions.json
@@ -1,0 +1,44 @@
+[
+   {
+      "queries":[
+         {
+            "query":"What can you do for me?",
+            "expectedAnswer":"As a customer service representative for a credit card company, I can assist you with the following:\r\n\r\nProvide information about your spending by category on a weekly basis.\r\nVisualize your spending data in various formats such as bar, line, column, or pie charts.\r\nProvide information about your total spending by day for a specified time period.\r\nProvide a list of all your credit card transactions within a specified time period.\r\nPlease let me know how I can assist you further.",
+            "expectedAnswerType":"TEXT"
+         },
+         {
+            "query":"Can you show me my most expensive transactions from this month?",
+            "expectedAnswer":"Here are your most expensive transactions:\n\n| Time | Card Number | Amount | Merchant Name | Category |\n| --- | --- | --- | --- | --- |\n| 2024-01-06T02:44:12.417Z | 6011082578613368 | 2153.57 | Mann-Bahringer | Housing & Utilities |\n| 2024-01-06T02:37:45.002Z | 349014230462591 | 816.66 | Murphy Group | Miscellaneous |\n| 2024-01-06T19:06:38.795Z | 6771896281778683 | 860.51 | Howe and Sons | Housing & Utilities |\n| 2024-01-06T07:53:56.300Z | 349014230462591 | 582.98 | Balistreri-Schiller | Groceries |\n| 2024-01-06T03:41:39.467Z | 349014230462591 | 492.76 | Mraz, Ankunding and Dietrich | Groceries |\n| 2024-01-07T02:50:28.249Z | 6011082578613368 | 633.67 | Leuschke LLC | Miscellaneous |\n| 2024-01-07T02:13:26.804Z | 6771896281778683 | 606.2 | Fisher, Gusikowski and Denesik | Miscellaneous |\n| 2024-01-06T02:00:02.470Z | 6011082578613368 | 606.8 | Paucek Inc | Groceries |\n| 2024-01-06T01:23:47.058Z | 349014230462591 | 683.93 | Franecki, Kihn and Von | Transportation |\n| 2024-01-07T00:50:38.426Z | 6011082578613368 | 276.8 | Wuckert-Ondricka | Clothing & Apparel |\n| 2024-01-06T21:30:34.596Z | 6011082578613368 | 269.47 | Kuphal Inc | Restaurants & Dining |\n| 2024-01-06T18:03:03.054Z | 349014230462591 | 176.4 | Grant and Sons | Clothing & Apparel |\n|",
+            "expectedAnswerType":"TEXT"
+         }
+      ]
+   },
+   {
+      "queries":[
+         {
+            "query":"Show me a breakdown of my expenses by categories",
+            "expectedAnswer":"{\"function\": \"data_visualization\", \"parameters\": {\"values\":[453.2,1802.59,3014.08,2056.53,395.55,683.93],\"chartType\":\"pie\",\"title\":\"Spending by Category\",\"labels\":[\"Clothing & Apparel\",\"Groceries\",\"Housing & Utilities\",\"Miscellaneous\",\"Restaurants & Dining\",\"Transportation\"],\"caption\":\"This pie chart represents your spending by category for the week ending on 2024-01-10.\"}}",
+            "expectedAnswerType":"FUNCTION_CALL"
+         },
+         {
+            "query":"Show this as a column chart",
+            "expectedAnswer":"{{\"function\": \"data_visualization\", \"parameters\": {\"values\":[453.2,1802.59,3014.08,2056.53,395.55,683.93],\"chartType\":\"column\",\"title\":\"Spending by Category\",\"labels\":[\"Clothing & Apparel\",\"Groceries\",\"Housing & Utilities\",\"Miscellaneous\",\"Restaurants & Dining\",\"Transportation\"],\"caption\":\"This column chart represents your spending by category for the week ending on 2024-01-10.\"}}",
+            "expectedAnswerType":"FUNCTION_CALL"
+         }
+      ]
+   },
+   {
+      "queries":[
+         {
+            "query":"How much have I spent on food last week?",
+            "expectedAnswer":"In the last week, you have spent $310.35 on groceries and $673.43 on restaurants and dining. Therefore, your total spending on food in the last week is $983.78.",
+            "expectedAnswerType":"TEXT"
+         },
+         {
+            "query":"And how much did I spend on fun in the week prior to that?",
+            "expectedAnswer":"You have spent $310.35 on restaurants and $673.43 on bars. Therefore, your total spending on fun in the last week is $983.78.",
+            "expectedAnswerType":"TEXT"
+         }
+      ]
+   }
+]

--- a/java/acorn-bedrock/src/main/java/com/datasqrl/ai/models/bedrock/BedrockChatProviderFactory.java
+++ b/java/acorn-bedrock/src/main/java/com/datasqrl/ai/models/bedrock/BedrockChatProviderFactory.java
@@ -1,5 +1,6 @@
 package com.datasqrl.ai.models.bedrock;
 
+import com.datasqrl.ai.tool.ModelObservability;
 import com.datasqrl.ai.tool.ToolsBackend;
 import com.datasqrl.ai.models.ChatProvider;
 import com.datasqrl.ai.models.ChatProviderFactory;
@@ -17,7 +18,7 @@ public class BedrockChatProviderFactory implements ChatProviderFactory {
   }
 
   @Override
-  public ChatProvider<?, ?> create(Configuration modelConfiguration, ToolsBackend backend, String prompt) {
-    return new BedrockChatProvider(new BedrockModelConfiguration(modelConfiguration), backend, prompt);
+  public ChatProvider<?, ?> create(Configuration modelConfiguration, ToolsBackend backend, String prompt, ModelObservability observability) {
+    return new BedrockChatProvider(new BedrockModelConfiguration(modelConfiguration), backend, prompt, observability);
   }
 }

--- a/java/acorn-bedrock/src/main/java/com/datasqrl/ai/models/bedrock/BedrockTokenCounter.java
+++ b/java/acorn-bedrock/src/main/java/com/datasqrl/ai/models/bedrock/BedrockTokenCounter.java
@@ -18,7 +18,7 @@ public record BedrockTokenCounter(HuggingFaceTokenizer tokenizer) implements Mod
     return numTokens + numTokens / 10; //Add a 10% buffer
   }
 
-  private int countTokens(String message) {
+  public int countTokens(String message) {
     if (message == null) {
       return 0;
     }

--- a/java/acorn-comparison/pom.xml
+++ b/java/acorn-comparison/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.datasqrl</groupId>
+        <artifactId>acorn</artifactId>
+        <version>0.1.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>acorn-comparison</artifactId>
+    <name>Acorn - Model Comparison</name>
+    <packaging>jar</packaging>
+
+
+    <properties>
+        <micrometer.version>1.13.1</micrometer.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.datasqrl</groupId>
+            <artifactId>acorn-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.datasqrl</groupId>
+            <artifactId>acorn-openai</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.datasqrl</groupId>
+            <artifactId>acorn-groq</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.datasqrl</groupId>
+            <artifactId>acorn-bedrock</artifactId>
+            <version>${project.version}</version>
+        </dependency>    
+        <dependency>
+            <groupId>com.datasqrl</groupId>
+            <artifactId>acorn-vertex</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.datasqrl</groupId>
+            <artifactId>acorn-spring</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/java/acorn-comparison/src/main/java/com/datasqrl/ai/comparison/ComparisonRunner.java
+++ b/java/acorn-comparison/src/main/java/com/datasqrl/ai/comparison/ComparisonRunner.java
@@ -1,0 +1,133 @@
+package com.datasqrl.ai.comparison;
+
+import com.datasqrl.ai.comparison.config.ComparisonConfiguration;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static com.datasqrl.ai.comparison.config.ComparisonConfiguration.MODEL_PREFIX;
+import static com.datasqrl.ai.models.ChatProviderFactory.MODEL_PROVIDER_KEY;
+
+@Slf4j
+@Value
+public class ComparisonRunner {
+
+  List<String> modelFiles;
+  List<String> useCaseFolders;
+  String scriptFile;
+  ObjectMapper mapper = new ObjectMapper();
+  SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+
+  public ComparisonRunner(List<String> modelFiles, List<String> useCaseFolders, String scriptFile) {
+    this.modelFiles = modelFiles;
+    this.useCaseFolders = useCaseFolders;
+    this.scriptFile = scriptFile;
+    log.info("modelFiles: {}\n useCaseFolders: {}\n scriptFile: {}", modelFiles, useCaseFolders, scriptFile);
+  }
+
+  public void start() throws IOException {
+    useCaseFolders.forEach(useCaseFolder -> {
+      log.info("Loading use case from {}", useCaseFolder);
+      Path useCaseDir = Paths.get(useCaseFolder);
+      Optional<Path> useCaseConfig = loadUseCaseConfig(useCaseDir);
+      Optional<Path> tools = loadTools(useCaseDir);
+      if (useCaseConfig.isPresent() && tools.isPresent()) {
+        List<TestChatSession> testSessions = loadTestChatSessionsFromFile(scriptFile);
+        log.info("Loaded {} test sessions from {}", testSessions.size(), scriptFile);
+        modelFiles.forEach(modelConfig -> {
+          log.info("Loading model config from {}", modelConfig);
+          SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+          ComparisonConfiguration configuration = ComparisonConfiguration.fromFile(Path.of(modelConfig), useCaseConfig.get(), tools.get(), meterRegistry);
+          AtomicInteger idCounter = new AtomicInteger(0);
+          String modelName = configuration.getModelConfiguration().getString(MODEL_PROVIDER_KEY) + "-" + configuration.getModelConfiguration().getString(MODEL_PREFIX);
+          String fileName = modelName + "-" + getCurrentTime();
+          testSessions.forEach(session -> {
+            log.info("Running session with userId: {}", idCounter.getAndIncrement());
+            new SessionRunner(configuration, session, idCounter, fileName).run();
+          });
+          log.info("Metrics results (CSV): {}", configuration.getChatProvider().getObservability().exportToCSV());
+          meterRegistry.close();
+        });
+      } else {
+        log.error("Could not load configuration and UseCase config from folder {}", useCaseFolder);
+      }
+    });
+  }
+
+  private Optional<Path> loadTools(Path useCaseDir) {
+    try (Stream<Path> stream = Files.list(useCaseDir)) {
+      return stream.filter(path -> !Files.isDirectory(path)).filter(path -> path.getFileName().toString().endsWith(".tools.json")).findFirst();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private Optional<Path> loadUseCaseConfig(Path useCaseDir) {
+    try (Stream<Path> stream = Files.list(useCaseDir)) {
+      return stream.filter(path -> !Files.isDirectory(path)).filter(path -> path.getFileName().toString().endsWith(".config.json")).findFirst();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private List<TestChatSession> loadTestChatSessionsFromFile(String fileName) {
+    try {
+      return mapper.readValue(Paths.get(fileName).toFile(), new TypeReference<List<TestChatSession>>() {
+      });
+    } catch (Exception ex) {
+      log.error("Could not read test chat sessions from {}", fileName, ex);
+    }
+    return List.of();
+  }
+
+  private String getCurrentTime() {
+    Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+    return sdf.format(timestamp);
+  }
+
+  public static void main(String... args) throws Exception {
+    if (args == null || args.length != 3)
+      throw new IllegalArgumentException("Please provide a models folder, a use case folder and a script file");
+    List<String> modelFiles;
+    List<String> useCaseFolders;
+    String scriptFile = args[2];
+    try (Stream<Path> stream = Files.list(Paths.get(args[0]))) {
+      modelFiles = stream
+          .filter(file -> !Files.isDirectory(file))
+          .filter(file -> file.getFileName().toString().endsWith(".json"))
+          .map(Path::toString)
+          .toList();
+    }
+    try (Stream<Path> stream = Files.list(Paths.get(args[1]))) {
+      useCaseFolders = stream
+          .filter(Files::isDirectory)
+          .map(Path::toString)
+          .toList();
+    }
+
+    ComparisonRunner runner = new ComparisonRunner(modelFiles, useCaseFolders, scriptFile);
+    runner.start();
+  }
+
+  private static class CustomLoggingMeterRegistry extends LoggingMeterRegistry {
+    @Override
+    public void publish() {
+      super.publish();
+    }
+  }
+
+}

--- a/java/acorn-comparison/src/main/java/com/datasqrl/ai/comparison/MicrometerModelObservability.java
+++ b/java/acorn-comparison/src/main/java/com/datasqrl/ai/comparison/MicrometerModelObservability.java
@@ -1,0 +1,87 @@
+package com.datasqrl.ai.comparison;
+
+import com.datasqrl.ai.tool.ModelObservability;
+import com.google.common.base.Stopwatch;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Value
+public class MicrometerModelObservability implements ModelObservability {
+
+  public static final String APP_NAME_TAG = "app";
+
+  MeterRegistry meterRegistry;
+  Timer latencyTimer;
+  DistributionSummary inputTokenCounter;
+  DistributionSummary outputTokenCounter;
+  DistributionSummary functionRetryCounter;
+
+  public MicrometerModelObservability(MeterRegistry meterRegistry, String applicationName) {
+    this.meterRegistry = meterRegistry;
+    this.latencyTimer = Timer.builder("model.execution.time")
+        .tags(APP_NAME_TAG, applicationName)
+        .publishPercentileHistogram()
+        .publishPercentiles(0.1, 0.5, 0.9)
+        .register(meterRegistry);
+    this.inputTokenCounter = DistributionSummary.builder("model.tokens.input")
+        .tags(APP_NAME_TAG, applicationName)
+        .register(meterRegistry);
+    this.outputTokenCounter = DistributionSummary.builder("model.tokens.output")
+        .tags(APP_NAME_TAG, applicationName)
+        .register(meterRegistry);
+    this.functionRetryCounter = DistributionSummary.builder("function.call.retries")
+        .tags(APP_NAME_TAG, applicationName)
+        .register(meterRegistry);
+  }
+
+  @Override
+  public Trace start() {
+    return new StandardTrace();
+  }
+
+  @Override
+  public String exportToCSV() {
+    StringBuilder s = new StringBuilder();
+    s.append(latencyTimer.count()).append(", ");
+    s.append(latencyTimer.totalTime(TimeUnit.MILLISECONDS)).append(", ");
+    s.append(latencyTimer.mean(TimeUnit.MILLISECONDS)).append(", ");
+//    for (ValueAtPercentile valueAtPercentile : latencyTimer.takeSnapshot().percentileValues()) {
+//      s.append(valueAtPercentile.percentile()).append(":");
+//      s.append(valueAtPercentile.value(TimeUnit.MILLISECONDS)).append(", ");
+//    }
+    s.append(latencyTimer.max(TimeUnit.MILLISECONDS)).append(", ");
+    s.append(inputTokenCounter.totalAmount()).append(", ");
+    s.append(inputTokenCounter.mean()).append(", ");
+    s.append(outputTokenCounter.totalAmount()).append(", ");
+    s.append(outputTokenCounter.mean()).append(", ");
+    s.append(functionRetryCounter.totalAmount());
+    return s.toString();
+  }
+
+  @Value
+  @AllArgsConstructor
+  public class StandardTrace implements Trace {
+
+    Stopwatch timer = Stopwatch.createStarted();
+
+    @Override
+    public void stop() {
+      timer.stop();
+    }
+
+    @Override
+    public void complete(int numInputTokens, int numOutputTokens, boolean retry) {
+      latencyTimer.record(timer.elapsed());
+      inputTokenCounter.record(numInputTokens);
+      outputTokenCounter.record(numOutputTokens);
+      functionRetryCounter.record(retry ? 1 : 0);
+    }
+  }
+}

--- a/java/acorn-comparison/src/main/java/com/datasqrl/ai/comparison/SessionLog.java
+++ b/java/acorn-comparison/src/main/java/com/datasqrl/ai/comparison/SessionLog.java
@@ -1,0 +1,11 @@
+package com.datasqrl.ai.comparison;
+
+import java.util.List;
+
+public record SessionLog(List<LogEntry> entries) {
+
+  public record LogEntry(String query, String expectedResponse, String actualResponse,
+                         TestChatSession.ChatQuery.AnswerType expectedAnswerType,
+                         TestChatSession.ChatQuery.AnswerType actualAnswerType) {
+  }
+}

--- a/java/acorn-comparison/src/main/java/com/datasqrl/ai/comparison/SessionRunner.java
+++ b/java/acorn-comparison/src/main/java/com/datasqrl/ai/comparison/SessionRunner.java
@@ -1,0 +1,102 @@
+package com.datasqrl.ai.comparison;
+
+import com.datasqrl.ai.comparison.config.ComparisonConfiguration;
+import com.datasqrl.ai.config.ContextConversion;
+import com.datasqrl.ai.models.ChatProvider;
+import com.datasqrl.ai.tool.GenericChatMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SequenceWriter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Slf4j
+public class SessionRunner {
+
+  private final TestChatSession testSession;
+  private final ChatProvider chatProvider;
+  private final List<String> contextKeys;
+  private final String logName;
+  private final AtomicInteger userId;
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  public SessionRunner(ComparisonConfiguration configuration, TestChatSession testChatSession, AtomicInteger userId, String logName) {
+    this.testSession = testChatSession;
+    this.userId = userId;
+    this.logName = logName;
+    this.contextKeys = configuration.getContext();
+    chatProvider = configuration.getChatProvider();
+  }
+
+  public void run() {
+    String jsonFileName = logName + ".json";
+    String txtFileName = logName + ".txt";
+    log.info("Running session with userId: {}", userId.get());
+    Map<String, Object> context = ContextConversion.getContextFromUserId(Integer.toString(userId.get()), contextKeys);
+    SessionLog sessionLog = runChatSession(testSession, context, txtFileName);
+    writeToFile(sessionLog, jsonFileName);
+  }
+
+  private void writeToFile(String s, String fileName) {
+    File file = new File(fileName);
+    try (FileWriter fileWriter = new FileWriter(file, true)) {
+      fileWriter.write(s);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void writeToFile(SessionLog sessionLog, String fileName) {
+    File file = new File(fileName);
+    try (FileWriter fileWriter = new FileWriter(file, true)) {
+      SequenceWriter seqWriter = mapper.writer().writeValuesAsArray(fileWriter);
+      seqWriter.write(sessionLog);
+      seqWriter.close();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private SessionLog runChatSession(TestChatSession session, Map<String, Object> context, String fileName) {
+    List<SessionLog.LogEntry> sessions = new ArrayList<>();
+    session.queries().forEach(query -> {
+      log.info("Query: {}", query.query());
+      GenericChatMessage response;
+      try {
+         response = chatProvider.chat(query.query(), context);
+        log.info("Response: {}", response.getContent());
+      } catch (Exception e) {
+        log.error("Query failed", e);
+        response = GenericChatMessage.builder().content("Error: " + e.getMessage()).build();
+      }
+      SessionLog.LogEntry logEntry = logInteraction(query, response);
+      String logString = serializeLogEntry(logEntry);
+      writeToFile(logString, fileName);
+      sessions.add(logEntry);
+    });
+    SessionLog logs = new SessionLog(sessions);
+//    log.info("SessionLog: {}", logs);
+    return logs;
+  }
+
+  private String serializeLogEntry(SessionLog.LogEntry logEntry) {
+    return "Query: " + logEntry.query() + "\n"
+        + "Expected Response: " + logEntry.expectedResponse() + "\n"
+        + "Actual Response: " + logEntry.actualResponse() + "\n"
+        + "Expected Answer Type: " + logEntry.expectedAnswerType() + "\n"
+        + "Actual Answer Type: " + logEntry.actualAnswerType() + "\n\n\n";
+
+  }
+
+  private SessionLog.LogEntry logInteraction(TestChatSession.ChatQuery query, GenericChatMessage response) {
+    TestChatSession.ChatQuery.AnswerType answerType =
+        response.getFunctionCall() == null ? TestChatSession.ChatQuery.AnswerType.TEXT : TestChatSession.ChatQuery.AnswerType.FUNCTION_CALL;
+    return new SessionLog.LogEntry(query.query(), query.expectedAnswer(), response.getContent(), query.expectedAnswerType(), answerType);
+  }
+}

--- a/java/acorn-comparison/src/main/java/com/datasqrl/ai/comparison/TestChatSession.java
+++ b/java/acorn-comparison/src/main/java/com/datasqrl/ai/comparison/TestChatSession.java
@@ -1,0 +1,14 @@
+package com.datasqrl.ai.comparison;
+
+import java.util.List;
+
+public record TestChatSession(List<ChatQuery> queries) {
+
+  public record ChatQuery(String query, String expectedAnswer, AnswerType expectedAnswerType) {
+
+    public enum AnswerType {
+      TEXT, FUNCTION_CALL
+    }
+  }
+
+}

--- a/java/acorn-comparison/src/main/java/com/datasqrl/ai/comparison/api/LocalAPIExecutor.java
+++ b/java/acorn-comparison/src/main/java/com/datasqrl/ai/comparison/api/LocalAPIExecutor.java
@@ -1,0 +1,92 @@
+package com.datasqrl.ai.comparison.api;
+
+import com.datasqrl.ai.api.APIExecutor;
+import com.datasqrl.ai.api.APIQuery;
+import com.datasqrl.ai.util.ErrorHandling;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Value
+public class LocalAPIExecutor implements APIExecutor {
+
+  Map<String, Map<String, String>> localResults;
+  List<JsonNode> chatMessages = new ArrayList<>();
+  String useCase;
+  ObjectMapper mapper = new ObjectMapper();
+
+  public LocalAPIExecutor(String useCase) {
+    this.useCase = useCase;
+    localResults = new HashMap<>();
+    Map<String, String> creditCardResults = new HashMap<>();
+    creditCardResults.put("GetTransactions", "{\"data\":{\"Transactions\":[{\"time\":\"2024-06-02T20:28:21.780Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":339.7,\"merchantName\":\"Kuhlman, Luettgen and Hahn\",\"category\":\"Education\"},{\"time\":\"2024-06-02T20:10:48.319Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":316.26,\"merchantName\":\"Kuphal Inc\",\"category\":\"Restaurants & Dining\"},{\"time\":\"2024-06-02T18:12:56.884Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":220.5,\"merchantName\":\"Kuphal Inc\",\"category\":\"Restaurants & Dining\"},{\"time\":\"2024-06-02T14:41:33.975Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":112.99,\"merchantName\":\"Paucek, Pfeffer and Nolan\",\"category\":\"Clothing & Apparel\"},{\"time\":\"2024-06-02T07:12:19.291Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":230.11,\"merchantName\":\"Sanford and Sons\",\"category\":\"Restaurants & Dining\"},{\"time\":\"2024-06-02T06:06:46.321Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":743.51,\"merchantName\":\"Kutch and Sons\",\"category\":\"Groceries\"},{\"time\":\"2024-06-02T05:11:50.048Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":225.64,\"merchantName\":\"Kulas Group\",\"category\":\"Communication\"},{\"time\":\"2024-06-02T02:36:19.692Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":221.17,\"merchantName\":\"Schaden and Sons\",\"category\":\"Communication\"},{\"time\":\"2024-06-02T00:42:13.873Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":2772.48,\"merchantName\":\"Howe and Sons\",\"category\":\"Housing & Utilities\"},{\"time\":\"2024-06-01T15:38:09.333Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":282.79,\"merchantName\":\"Considine Inc\",\"category\":\"Groceries\"},{\"time\":\"2024-06-01T09:59:44.147Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":46.85,\"merchantName\":\"McKenzie, Harris and Casper\",\"category\":\"Entertainment\"},{\"time\":\"2024-06-01T06:31:18.855Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":784.49,\"merchantName\":\"Batz-Boyle\",\"category\":\"Transportation\"},{\"time\":\"2024-06-01T04:28:40.675Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":376.71,\"merchantName\":\"Gibson and Sons\",\"category\":\"Transportation\"},{\"time\":\"2024-06-01T01:00:38.614Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":2620.14,\"merchantName\":\"Beahan-Fahey\",\"category\":\"Housing & Utilities\"},{\"time\":\"2024-05-31T22:24:55.690Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":132.95,\"merchantName\":\"Sanford and Sons\",\"category\":\"Restaurants & Dining\"},{\"time\":\"2024-05-31T15:40:22.865Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":234.38,\"merchantName\":\"Grant LLC\",\"category\":\"Clothing & Apparel\"},{\"time\":\"2024-05-31T15:08:34.895Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":442.09,\"merchantName\":\"Ebert, Okuneva and McKenzie\",\"category\":\"Travel & Vacations\"},{\"time\":\"2024-05-31T14:58:28.770Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":173.01,\"merchantName\":\"Stroman, Torp and Lockman\",\"category\":\"Restaurants & Dining\"},{\"time\":\"2024-05-31T13:08:36.590Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":73.9,\"merchantName\":\"Block, Huels and Windler\",\"category\":\"Groceries\"},{\"time\":\"2024-05-31T09:53:11.984Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":68.17,\"merchantName\":\"Hayes Group\",\"category\":\"Restaurants & Dining\"},{\"time\":\"2024-05-31T08:59:52.286Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":314.46,\"merchantName\":\"Balistreri-Schiller\",\"category\":\"Groceries\"},{\"time\":\"2024-05-31T08:13:40.897Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":461.71,\"merchantName\":\"Gleason-King\",\"category\":\"Education\"},{\"time\":\"2024-05-31T03:49:23.637Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":185.03,\"merchantName\":\"Grant and Sons\",\"category\":\"Clothing & Apparel\"},{\"time\":\"2024-05-31T03:15:49.200Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":853.18,\"merchantName\":\"Corwin, Erdman and Koelpin\",\"category\":\"Travel & Vacations\"},{\"time\":\"2024-05-30T19:06:53.015Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":320.83,\"merchantName\":\"Sanford and Sons\",\"category\":\"Restaurants & Dining\"},{\"time\":\"2024-05-30T17:20:29.777Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":394.74,\"merchantName\":\"Block, Huels and Windler\",\"category\":\"Groceries\"},{\"time\":\"2024-05-30T17:08:07.250Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":266.45,\"merchantName\":\"Ledner, Brown and Torp\",\"category\":\"Groceries\"},{\"time\":\"2024-05-30T14:30:13.135Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":111.69,\"merchantName\":\"Wolff Inc\",\"category\":\"Restaurants & Dining\"},{\"time\":\"2024-05-30T12:32:23.483Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":479.01,\"merchantName\":\"Lockman-Langosh\",\"category\":\"Travel & Vacations\"},{\"time\":\"2024-05-30T12:07:45.001Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":633.62,\"merchantName\":\"Gleason-King\",\"category\":\"Education\"},{\"time\":\"2024-05-30T04:48:59.258Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":2313.07,\"merchantName\":\"Beahan-Fahey\",\"category\":\"Housing & Utilities\"},{\"time\":\"2024-05-30T04:09:37.331Z\",\"cardNo\":\"4.680990142304E12\",\"amount\":810.85,\"merchantName\":\"Schaden-Goldner\",\"category\":\"Housing & Utilities\"}]}}");
+    creditCardResults.put("SpendingByCategory", "{\"data\":{\"SpendingByCategory\":[{\"timeWeek\":\"2024-05-29T23:59:59.999Z\",\"category\":\"Childcare\",\"spending\":6990.1},{\"timeWeek\":\"2024-05-29T23:59:59.999Z\",\"category\":\"Clothing & Apparel\",\"spending\":2118.11},{\"timeWeek\":\"2024-05-29T23:59:59.999Z\",\"category\":\"Communication\",\"spending\":119.07},{\"timeWeek\":\"2024-05-29T23:59:59.999Z\",\"category\":\"Education\",\"spending\":979.14},{\"timeWeek\":\"2024-05-29T23:59:59.999Z\",\"category\":\"Entertainment\",\"spending\":225.36},{\"timeWeek\":\"2024-05-29T23:59:59.999Z\",\"category\":\"Groceries\",\"spending\":1244.27},{\"timeWeek\":\"2024-05-29T23:59:59.999Z\",\"category\":\"Health & Wellness\",\"spending\":1678.88},{\"timeWeek\":\"2024-05-29T23:59:59.999Z\",\"category\":\"Housing & Utilities\",\"spending\":12226.2},{\"timeWeek\":\"2024-05-29T23:59:59.999Z\",\"category\":\"Miscellaneous\",\"spending\":3410.91},{\"timeWeek\":\"2024-05-29T23:59:59.999Z\",\"category\":\"Restaurants & Dining\",\"spending\":778.7},{\"timeWeek\":\"2024-05-29T23:59:59.999Z\",\"category\":\"Transportation\",\"spending\":480.91},{\"timeWeek\":\"2024-05-29T23:59:59.999Z\",\"category\":\"Travel & Vacations\",\"spending\":7485.72}]}}");
+    creditCardResults.put("SpendingByDay", "{\"data\":{\"SpendingByDay\":[{\"timeDay\":\"2024-06-02T23:59:59.999Z\",\"spending\":5182.36},{\"timeDay\":\"2024-06-01T23:59:59.999Z\",\"spending\":4110.98},{\"timeDay\":\"2024-05-31T23:59:59.999Z\",\"spending\":2938.88},{\"timeDay\":\"2024-05-30T23:59:59.999Z\",\"spending\":5330.26},{\"timeDay\":\"2024-05-29T23:59:59.999Z\",\"spending\":11531.37},{\"timeDay\":\"2024-05-28T23:59:59.999Z\",\"spending\":7146.92}]}}");
+    creditCardResults.put("AddChatMsg", "\"data\":{\"AddChatMessage\":{\"event_time\":\"2024-07-05T08:46:28.910\"}}}");
+    localResults.put("finance", creditCardResults);
+  }
+
+  @Override
+  public void validate(APIQuery query) {
+    ErrorHandling.checkNotNullOrEmpty(query.getQuery(), "`query` cannot be empty");
+  }
+
+  @Override
+  public String executeQuery(APIQuery query, JsonNode arguments) {
+    String functionName = extractFunctionName(query);
+    if (functionName == null) {
+      throw new IllegalArgumentException("Could not extract function name from query: " + query.getQuery());
+    }
+    switch (functionName) {
+      case "GetChatMessages" -> {
+        return retrieveChatMessages();
+      }
+      case "AddChatMsg" -> {
+        chatMessages.add(0, arguments);
+        return localResults.get(useCase).get(functionName);
+      }
+      default -> {
+        if (localResults.get(useCase).containsKey(functionName)) {
+          return localResults.get(useCase).get(functionName);
+        } else {
+          throw new IllegalArgumentException("Unknown function: " + functionName + " in query: " + query.getQuery());
+        }
+      }
+    }
+
+  }
+
+  private String retrieveChatMessages() {
+    String messages = chatMessages.stream().map(value -> {
+      try {
+        return mapper.writeValueAsString(value);
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+    }).collect(Collectors.joining(","));
+    String response = "{\"data\":{\"messages\":[" + messages + "]}}";
+    log.debug("Chat Messages: {}", response);
+    return response;
+  }
+
+  private String extractFunctionName(APIQuery query) {
+    Pattern pattern = Pattern.compile("\\s*[query|mutation]\\s*([a-zA-Z]+)\\(");
+    Matcher matcher = pattern.matcher(query.getQuery());
+    if (matcher.find()) {
+      return matcher.group(1).trim();
+    } else {
+      return null;
+    }
+  }
+}

--- a/java/acorn-comparison/src/main/java/com/datasqrl/ai/comparison/api/LocalAPIExecutorFactory.java
+++ b/java/acorn-comparison/src/main/java/com/datasqrl/ai/comparison/api/LocalAPIExecutorFactory.java
@@ -1,0 +1,28 @@
+package com.datasqrl.ai.comparison.api;
+
+import com.datasqrl.ai.api.APIExecutor;
+import com.datasqrl.ai.api.APIExecutorFactory;
+import com.datasqrl.ai.util.ErrorHandling;
+import com.google.auto.service.AutoService;
+import org.apache.commons.configuration2.Configuration;
+
+import java.util.Optional;
+
+@AutoService(APIExecutorFactory.class)
+public class LocalAPIExecutorFactory implements APIExecutorFactory {
+
+  public static final String TYPE = "local";
+  static final String USE_CASE_KEY = "use_case";
+
+  @Override
+  public String getTypeName() {
+    return TYPE;
+  }
+
+  @Override
+  public APIExecutor create(Configuration configuration, String name) {
+    Optional<String> useCase = Optional.ofNullable(configuration.getString(USE_CASE_KEY));
+    ErrorHandling.checkArgument(useCase.isPresent(), "Need to configure `%s` in api configuration.", USE_CASE_KEY, name);
+    return new LocalAPIExecutor(useCase.get());
+  }
+}

--- a/java/acorn-core/src/main/java/com/datasqrl/ai/models/ChatProvider.java
+++ b/java/acorn-core/src/main/java/com/datasqrl/ai/models/ChatProvider.java
@@ -1,5 +1,6 @@
 package com.datasqrl.ai.models;
 
+import com.datasqrl.ai.tool.ModelObservability;
 import com.datasqrl.ai.tool.ToolsBackend;
 import com.datasqrl.ai.tool.GenericChatMessage;
 import java.util.List;
@@ -16,6 +17,8 @@ public abstract class ChatProvider<Message, FunctionCall> {
   protected final ToolsBackend backend;
   @Getter
   protected final ModelBindings<Message, FunctionCall> bindings;
+  @Getter
+  protected final ModelObservability observability;
 
   public abstract GenericChatMessage chat(String message, Map<String, Object> context);
 

--- a/java/acorn-core/src/main/java/com/datasqrl/ai/models/ChatProviderFactory.java
+++ b/java/acorn-core/src/main/java/com/datasqrl/ai/models/ChatProviderFactory.java
@@ -1,5 +1,6 @@
 package com.datasqrl.ai.models;
 
+import com.datasqrl.ai.tool.ModelObservability;
 import com.datasqrl.ai.tool.ToolsBackend;
 import com.datasqrl.ai.util.ErrorHandling;
 import java.util.Map;
@@ -15,7 +16,7 @@ public interface ChatProviderFactory {
 
   String getProviderName();
 
-  ChatProvider<?, ?> create(Configuration modelConfiguration, ToolsBackend backend, String prompt);
+  ChatProvider<?, ?> create(Configuration modelConfiguration, ToolsBackend backend, String prompt, ModelObservability observability);
 
   static ChatProviderFactory fromConfiguration(Configuration modelConfiguration) {
     String provider = modelConfiguration.getString(MODEL_PROVIDER_KEY);
@@ -27,9 +28,9 @@ public interface ChatProviderFactory {
     return providerFact.get();
   }
 
-  static ChatProvider<?,?> fromConfiguration(Map<String, Object> modelConfiguration, ToolsBackend backend, String prompt) {
+  static ChatProvider<?,?> fromConfiguration(Map<String, Object> modelConfiguration, ToolsBackend backend, String prompt, ModelObservability observability) {
     MapConfiguration configuration = new MapConfiguration(modelConfiguration);
-    return fromConfiguration(configuration).create(configuration,backend, prompt);
+    return fromConfiguration(configuration).create(configuration,backend, prompt, observability);
   }
 
 }

--- a/java/acorn-core/src/main/java/com/datasqrl/ai/models/ModelAnalyzer.java
+++ b/java/acorn-core/src/main/java/com/datasqrl/ai/models/ModelAnalyzer.java
@@ -7,4 +7,5 @@ public interface ModelAnalyzer<ChatMessage> {
 
   int countTokens(ChatMessage message);
 
+  int countTokens(String generation);
 }

--- a/java/acorn-core/src/main/java/com/datasqrl/ai/tool/ModelObservability.java
+++ b/java/acorn-core/src/main/java/com/datasqrl/ai/tool/ModelObservability.java
@@ -1,0 +1,39 @@
+package com.datasqrl.ai.tool;
+
+public interface ModelObservability {
+
+  Trace start();
+
+  String exportToCSV();
+
+  public interface Trace {
+
+    void stop();
+
+    void complete(int numInputTokens, int numOutputTokens, boolean retry);
+
+  }
+
+  public static final ModelObservability NOOP = new ModelObservability() {
+    @Override
+    public Trace start() {
+      return new Trace() {
+        @Override
+        public void stop() {
+
+        }
+
+        @Override
+        public void complete(int numInputTokens, int numOutputTokens, boolean retry) {
+
+        }
+      };
+    }
+
+    @Override
+    public String exportToCSV() {
+      return "";
+    }
+  };
+
+}

--- a/java/acorn-groq/src/main/java/com/datasqrl/ai/models/groq/GroqChatProvider.java
+++ b/java/acorn-groq/src/main/java/com/datasqrl/ai/models/groq/GroqChatProvider.java
@@ -5,6 +5,7 @@ import static com.theokanning.openai.service.OpenAiService.defaultObjectMapper;
 
 import com.datasqrl.ai.models.ChatSession;
 import com.datasqrl.ai.models.ContextWindow;
+import com.datasqrl.ai.tool.ModelObservability;
 import com.datasqrl.ai.tool.ToolsBackend;
 import com.datasqrl.ai.tool.GenericChatMessage;
 import com.datasqrl.ai.models.ChatProvider;
@@ -51,8 +52,8 @@ public class GroqChatProvider extends ChatProvider<ChatMessage, ChatFunctionCall
   private ChatFunctionCall errorFunctionCall = null;
   public static final String GROQ_URL = "https://api.groq.com/openai/v1/";
 
-  public GroqChatProvider(GroqModelConfiguration config, ToolsBackend backend, String systemPrompt) {
-    super(backend, new GroqModelBindings(config));
+  public GroqChatProvider(GroqModelConfiguration config, ToolsBackend backend, String systemPrompt, ModelObservability observability) {
+    super(backend, new GroqModelBindings(config), observability);
     this.config = config;
     this.systemPrompt = systemPrompt;
     String groqApiKey = ConfigurationUtil.getEnvOrSystemVariable("GROQ_API_KEY");
@@ -96,9 +97,12 @@ public class GroqChatProvider extends ChatProvider<ChatMessage, ChatFunctionCall
           .logitBias(new HashMap<>())
           .build();
       AssistantMessage responseMessage;
+      ModelObservability.Trace modeltrace = observability.start();
       try {
         responseMessage = service.createChatCompletion(chatCompletionRequest).getChoices().get(0).getMessage();
+        modeltrace.stop();
       } catch (OpenAiHttpException e) {
+        modeltrace.stop();
         // Workaround for groq API bug that throws 400 on some function calls
         if (e.statusCode == 400 && errorFunctionCall != null) {
           responseMessage = new AssistantMessage("", "", null, errorFunctionCall);
@@ -126,9 +130,11 @@ public class GroqChatProvider extends ChatProvider<ChatMessage, ChatFunctionCall
         ChatSession.FunctionExecutionOutcome<ChatMessage> outcome = session.validateAndExecuteFunctionCall(functionCall, true);
         switch (outcome.status()) {
           case EXECUTE_ON_CLIENT -> {
+            modeltrace.complete(contextWindow.getNumTokens(), bindings.getTokenCounter().countTokens(responseMessage), false);
             return genericResponse;
           }
           case VALIDATION_ERROR_RETRY -> {
+            modeltrace.complete(contextWindow.getNumTokens(), bindings.getTokenCounter().countTokens(responseMessage), true);
             if (retryCount >= ChatProvider.FUNCTION_CALL_RETRIES_LIMIT) {
               throw new RuntimeException("Too many function call retries for the same function.");
             } else {
@@ -139,6 +145,7 @@ public class GroqChatProvider extends ChatProvider<ChatMessage, ChatFunctionCall
           }
         }
       } else {
+        modeltrace.complete(contextWindow.getNumTokens(), bindings.getTokenCounter().countTokens(responseMessage), false);
         // The text answer
         return genericResponse;
       }

--- a/java/acorn-groq/src/main/java/com/datasqrl/ai/models/groq/GroqChatProviderFactory.java
+++ b/java/acorn-groq/src/main/java/com/datasqrl/ai/models/groq/GroqChatProviderFactory.java
@@ -1,5 +1,6 @@
 package com.datasqrl.ai.models.groq;
 
+import com.datasqrl.ai.tool.ModelObservability;
 import com.datasqrl.ai.tool.ToolsBackend;
 import com.datasqrl.ai.models.ChatProvider;
 import com.datasqrl.ai.models.ChatProviderFactory;
@@ -17,7 +18,7 @@ public class GroqChatProviderFactory implements ChatProviderFactory {
   }
 
   @Override
-  public ChatProvider<?, ?> create(Configuration modelConfiguration, ToolsBackend backend, String prompt) {
-    return new GroqChatProvider(new GroqModelConfiguration(modelConfiguration), backend, prompt);
+  public ChatProvider<?, ?> create(Configuration modelConfiguration, ToolsBackend backend, String prompt, ModelObservability observability) {
+    return new GroqChatProvider(new GroqModelConfiguration(modelConfiguration), backend, prompt, observability);
   }
 }

--- a/java/acorn-groq/src/main/java/com/datasqrl/ai/models/groq/GroqTokenCounter.java
+++ b/java/acorn-groq/src/main/java/com/datasqrl/ai/models/groq/GroqTokenCounter.java
@@ -17,7 +17,7 @@ public record GroqTokenCounter(HuggingFaceTokenizer tokenizer) implements ModelA
     return numTokens + numTokens / 10; //Add a 10% buffer
   }
 
-  private int countTokens(String message) {
+  public int countTokens(String message) {
     if (message == null) {
       return 0;
     }

--- a/java/acorn-openai/src/main/java/com/datasqrl/ai/models/openai/OpenAITokenCounter.java
+++ b/java/acorn-openai/src/main/java/com/datasqrl/ai/models/openai/OpenAITokenCounter.java
@@ -21,7 +21,7 @@ public record OpenAITokenCounter(Encoding encoding) implements ModelAnalyzer<Cha
     return numTokens + numTokens / 10; //Add a 10% buffer
   }
 
-  private int countTokens(String message) {
+  public int countTokens(String message) {
     return encoding.countTokens(message);
   }
 

--- a/java/acorn-openai/src/main/java/com/datasqrl/ai/models/openai/OpenAiChatProvider.java
+++ b/java/acorn-openai/src/main/java/com/datasqrl/ai/models/openai/OpenAiChatProvider.java
@@ -2,6 +2,7 @@ package com.datasqrl.ai.models.openai;
 
 import com.datasqrl.ai.models.ChatSession;
 import com.datasqrl.ai.models.ContextWindow;
+import com.datasqrl.ai.tool.ModelObservability;
 import com.datasqrl.ai.tool.ToolsBackend;
 import com.datasqrl.ai.tool.GenericChatMessage;
 import com.datasqrl.ai.models.ChatProvider;
@@ -27,8 +28,8 @@ public class OpenAiChatProvider extends ChatProvider<ChatMessage, ChatFunctionCa
   private final OpenAiService service;
   private final String systemPrompt;
 
-  public OpenAiChatProvider(OpenAIModelConfiguration config, ToolsBackend backend, String systemPrompt) {
-    super(backend, new OpenAIModelBindings(config));
+  public OpenAiChatProvider(OpenAIModelConfiguration config, ToolsBackend backend, String systemPrompt, ModelObservability observability) {
+    super(backend, new OpenAIModelBindings(config), observability);
     this.config = config;
     this.systemPrompt = systemPrompt;
     String openAIToken = ConfigurationUtil.getEnvOrSystemVariable("OPENAI_API_KEY");
@@ -57,7 +58,9 @@ public class OpenAiChatProvider extends ChatProvider<ChatMessage, ChatFunctionCa
           .maxTokens(config.getMaxOutputTokens())
           .logitBias(new HashMap<>())
           .build();
+      ModelObservability.Trace modeltrace = observability.start();
       AssistantMessage responseMessage = service.createChatCompletion(chatCompletionRequest).getChoices().get(0).getMessage();
+      modeltrace.stop();
       log.debug("Response:\n{}", responseMessage);
       String res = responseMessage.getTextContent();
       // Workaround for openai4j who doesn't recognize some function calls
@@ -77,9 +80,11 @@ public class OpenAiChatProvider extends ChatProvider<ChatMessage, ChatFunctionCa
         ChatSession.FunctionExecutionOutcome<ChatMessage> outcome = session.validateAndExecuteFunctionCall(functionCall, true);
         switch (outcome.status()) {
           case EXECUTE_ON_CLIENT -> {
+            modeltrace.complete(contextWindow.getNumTokens(), bindings.getTokenCounter().countTokens(responseMessage), false);
             return genericResponse;
           }
           case VALIDATION_ERROR_RETRY -> {
+            modeltrace.complete(contextWindow.getNumTokens(), bindings.getTokenCounter().countTokens(responseMessage), true);
             if (retryCount >= ChatProvider.FUNCTION_CALL_RETRIES_LIMIT) {
               throw new RuntimeException("Too many function call retries for the same function.");
             } else {
@@ -90,6 +95,7 @@ public class OpenAiChatProvider extends ChatProvider<ChatMessage, ChatFunctionCa
           }
         }
       } else {
+        modeltrace.complete(contextWindow.getNumTokens(), bindings.getTokenCounter().countTokens(responseMessage), false);
         // The text answer
         return genericResponse;
       }

--- a/java/acorn-openai/src/main/java/com/datasqrl/ai/models/openai/OpenAiChatProviderFactory.java
+++ b/java/acorn-openai/src/main/java/com/datasqrl/ai/models/openai/OpenAiChatProviderFactory.java
@@ -1,5 +1,6 @@
 package com.datasqrl.ai.models.openai;
 
+import com.datasqrl.ai.tool.ModelObservability;
 import com.datasqrl.ai.tool.ToolsBackend;
 import com.datasqrl.ai.models.ChatProvider;
 import com.datasqrl.ai.models.ChatProviderFactory;
@@ -17,7 +18,7 @@ public class OpenAiChatProviderFactory implements ChatProviderFactory {
   }
 
   @Override
-  public ChatProvider<?, ?> create(Configuration modelConfiguration, ToolsBackend backend, String prompt) {
-    return new OpenAiChatProvider(new OpenAIModelConfiguration(modelConfiguration), backend, prompt);
+  public ChatProvider<?, ?> create(Configuration modelConfiguration, ToolsBackend backend, String prompt, ModelObservability observability) {
+    return new OpenAiChatProvider(new OpenAIModelConfiguration(modelConfiguration), backend, prompt, observability);
   }
 }

--- a/java/acorn-starter/src/test/java/com/datasqrl/ai/example/ConfigurableChatBot.java
+++ b/java/acorn-starter/src/test/java/com/datasqrl/ai/example/ConfigurableChatBot.java
@@ -6,6 +6,7 @@ import com.datasqrl.ai.api.GraphQLExecutorFactory;
 import com.datasqrl.ai.models.ChatProvider;
 import com.datasqrl.ai.models.ChatProviderFactory;
 import com.datasqrl.ai.tool.GenericChatMessage;
+import com.datasqrl.ai.tool.ModelObservability;
 import com.datasqrl.ai.tool.RuntimeFunctionDefinition;
 import com.datasqrl.ai.tool.ToolsBackend;
 import com.datasqrl.ai.tool.ToolsBackendFactory;
@@ -74,7 +75,7 @@ public class ConfigurableChatBot {
         "provider", "groq",
         "name", "mixtral-8x7b-32768",
         "temperature", 0.8
-    ), toolsBackend, systemPrompt);
+    ), toolsBackend, systemPrompt, ModelObservability.NOOP);
 
     ConfigurableChatBot chatBot = new ConfigurableChatBot(chatProvider);
     chatBot.start(Map.of());

--- a/java/acorn-vertex/src/main/java/com/datasqrl/ai/models/vertex/VertexChatProviderFactory.java
+++ b/java/acorn-vertex/src/main/java/com/datasqrl/ai/models/vertex/VertexChatProviderFactory.java
@@ -2,6 +2,7 @@ package com.datasqrl.ai.models.vertex;
 
 import com.datasqrl.ai.models.ChatProvider;
 import com.datasqrl.ai.models.ChatProviderFactory;
+import com.datasqrl.ai.tool.ModelObservability;
 import com.datasqrl.ai.tool.ToolsBackend;
 import com.google.auto.service.AutoService;
 import org.apache.commons.configuration2.Configuration;
@@ -17,7 +18,7 @@ public class VertexChatProviderFactory implements ChatProviderFactory {
   }
 
   @Override
-  public ChatProvider<?, ?> create(Configuration modelConfiguration, ToolsBackend backend, String prompt) {
-    return new VertexChatProvider(new VertexModelConfiguration(modelConfiguration), backend, prompt);
+  public ChatProvider<?, ?> create(Configuration modelConfiguration, ToolsBackend backend, String prompt, ModelObservability observability) {
+    return new VertexChatProvider(new VertexModelConfiguration(modelConfiguration), backend, prompt, observability);
   }
 }

--- a/java/acorn-vertex/src/main/java/com/datasqrl/ai/models/vertex/VertexTokenCounter.java
+++ b/java/acorn-vertex/src/main/java/com/datasqrl/ai/models/vertex/VertexTokenCounter.java
@@ -29,7 +29,7 @@ public record VertexTokenCounter(GenerativeModel model) implements ModelAnalyzer
   }
 
   @SneakyThrows
-  private int countTokens(String message) {
+  public int countTokens(String message) {
     return model.countTokens(message).getTotalTokens();
   }
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -18,6 +18,7 @@
     <module>acorn-config</module>
     <module>acorn-starter</module>
     <module>acorn-spring</module>
+    <module>acorn-comparison</module>
   </modules>
 
   <developers>


### PR DESCRIPTION
## Function Calling Comparison between LLMs
In the apirag-comparison module, we run a controlled experiment where we run a command line chatbot using pre-configured query sessions against many LLM configurations from different providers. The function calling to the backend is faked with hard-coded JSON locally, as the goal is to test the ability of the LLM to call functions at the right moment and in the right syntax.

We track the performance of the models on these dimensions:
- latency
- input / output tokens (cost)
- function call retries

We also save all interactions with the models in a log, in order to evaluate them qualitatively later (grading correct / incorrect and with a score of 1-5)

### Implementation details
In order to run the experiment, run the `ComparisonRunner` file with 3 command line arguments
- folder with model configurations (see /apiRAG/experiments/models)
- folder with use cases (a use case folder contains tools and a config) (see /apiRAG/experiments/use-cases)
- a json file with the chat sessions to be run (see /apiRAG/experiments/use-cases/finance/finance-agent.sessions.json)

You need to load all the API Keys as environment variables before running the experiment
- GROQ_API_KEY
- OPENAI_API_KEY
- AWS Credentials: AWS_ACCESS_KEY, AWS_SECRET_ACCCESS_KEY, AWS_SESSION_TOKEN(if needed)
- Log in to your Vertex account before, by running `gcloud auth login`(https://cloud.google.com/sdk/gcloud/reference/auth/login)

The metrics are being printed to the console after the run of each model.
Two log files are being written for each model, one in JSON format, and one in TXT format.