### PR TITLE
Makes config parameter max_output_tokens optional

### DIFF
--- a/java/acorn-bedrock/src/main/java/com/datasqrl/ai/models/bedrock/BedrockChatProvider.java
+++ b/java/acorn-bedrock/src/main/java/com/datasqrl/ai/models/bedrock/BedrockChatProvider.java
@@ -9,8 +9,10 @@ import com.datasqrl.ai.models.ChatProvider;
 import com.datasqrl.ai.models.ChatMessageEncoder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.util.Map;
 import java.util.stream.Collectors;
+
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
@@ -120,9 +122,11 @@ public class BedrockChatProvider extends ChatProvider<BedrockChatMessage, Bedroc
   private JSONObject promptBedrock(BedrockRuntimeClient client, String modelId, String prompt) {
     JSONObject request = new JSONObject()
         .put("prompt", prompt)
-        .put("max_gen_len", config.getMaxOutputTokens())
         .put("top_p", config.getTopP())
         .put("temperature", config.getTemperature());
+    if (config.hasMaxOutputTokens()) {
+      request.put("max_gen_len", config.getMaxOutputTokens());
+    }
     InvokeModelRequest invokeModelRequest = InvokeModelRequest.builder()
         .modelId(modelId)
         .body(SdkBytes.fromUtf8String(request.toString()))

--- a/java/acorn-bedrock/src/main/java/com/datasqrl/ai/models/bedrock/BedrockModelConfiguration.java
+++ b/java/acorn-bedrock/src/main/java/com/datasqrl/ai/models/bedrock/BedrockModelConfiguration.java
@@ -17,7 +17,6 @@ public class BedrockModelConfiguration extends AbstractModelConfiguration {
   public static final String REGION_KEY = "region";
   public static final String REGION_DEFAULT = "us-east-1";
   public static final String MAX_GENERATION_LENGTH_KEY = "max_gen_len";
-  public static final int MAX_OUTPUT_TOKENS = 2048;
 
   public BedrockModelConfiguration(Configuration configuration) {
     super(configuration);
@@ -41,11 +40,9 @@ public class BedrockModelConfiguration extends AbstractModelConfiguration {
   }
 
   @Override
-  public int getMaxOutputTokens() {
+  public Integer getMaxOutputTokens() {
     if (configuration.containsKey(MAX_GENERATION_LENGTH_KEY)) return configuration.getInt(MAX_GENERATION_LENGTH_KEY);
-    if (configuration.containsKey(AbstractModelConfiguration.MAX_OUTPUT_TOKENS_KEY))
-      return configuration.getInt(AbstractModelConfiguration.MAX_OUTPUT_TOKENS_KEY);
-    return MAX_OUTPUT_TOKENS;
+    return super.getMaxOutputTokens();
   }
 
   public String getRegion() {

--- a/java/acorn-core/src/main/java/com/datasqrl/ai/models/AbstractModelConfiguration.java
+++ b/java/acorn-core/src/main/java/com/datasqrl/ai/models/AbstractModelConfiguration.java
@@ -16,7 +16,7 @@ public abstract class AbstractModelConfiguration implements ModelConfiguration {
   public static final double TOP_P_DEFAULT = 0.9;
   public static final String TOKENIZER_KEY = "tokenizer";
 
-  public static final double OUTPUT_TOKEN_RATIO = 0.3;
+  public static final double INPUT_TOKEN_RATIO = 0.7;
 
   protected final Configuration configuration;
 
@@ -42,16 +42,21 @@ public abstract class AbstractModelConfiguration implements ModelConfiguration {
     if (configuration.containsKey(AbstractModelConfiguration.MAX_INPUT_TOKENS_KEY)) {
       return configuration.getInt(AbstractModelConfiguration.MAX_INPUT_TOKENS_KEY);
     } else {
-      return (int)Math.round(getMaxTokensForModel()*(1-OUTPUT_TOKEN_RATIO));
+      return (int) Math.round(getMaxTokensForModel() * INPUT_TOKEN_RATIO);
     }
   }
 
   @Override
-  public int getMaxOutputTokens() {
-    if (configuration.containsKey(AbstractModelConfiguration.MAX_OUTPUT_TOKENS_KEY)) {
+  public boolean hasMaxOutputTokens() {
+    return configuration.containsKey(AbstractModelConfiguration.MAX_OUTPUT_TOKENS_KEY);
+  }
+
+  @Override
+  public Integer getMaxOutputTokens() {
+    if (hasMaxOutputTokens()) {
       return configuration.getInt(AbstractModelConfiguration.MAX_OUTPUT_TOKENS_KEY);
     } else {
-      return (int)Math.round(getMaxTokensForModel()*(OUTPUT_TOKEN_RATIO));
+      return null;
     }
   }
 

--- a/java/acorn-core/src/main/java/com/datasqrl/ai/models/ModelConfiguration.java
+++ b/java/acorn-core/src/main/java/com/datasqrl/ai/models/ModelConfiguration.java
@@ -8,7 +8,9 @@ public interface ModelConfiguration {
 
   int getMaxInputTokens();
 
-  int getMaxOutputTokens();
+  boolean hasMaxOutputTokens();
+
+  Integer getMaxOutputTokens();
 
   double getTemperature();
 

--- a/java/acorn-groq/src/main/java/com/datasqrl/ai/models/groq/GroqChatProvider.java
+++ b/java/acorn-groq/src/main/java/com/datasqrl/ai/models/groq/GroqChatProvider.java
@@ -21,6 +21,7 @@ import com.theokanning.openai.completion.chat.ChatFunctionCall;
 import com.theokanning.openai.completion.chat.ChatMessage;
 import com.theokanning.openai.completion.chat.UserMessage;
 import com.theokanning.openai.service.OpenAiService;
+
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -28,6 +29,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
@@ -83,7 +85,7 @@ public class GroqChatProvider extends ChatProvider<ChatMessage, ChatFunctionCall
       log.info("Calling GROQ with model {}", config.getModelName());
       ContextWindow<ChatMessage> contextWindow = session.getContextWindow();
       log.debug("Calling GROQ with messages: {}", contextWindow.getMessages());
-      ChatCompletionRequest chatCompletionRequest = ChatCompletionRequest
+      ChatCompletionRequest.ChatCompletionRequestBuilder builder = ChatCompletionRequest
           .builder()
           .model(config.getModelName())
           .messages(contextWindow.getMessages())
@@ -91,9 +93,11 @@ public class GroqChatProvider extends ChatProvider<ChatMessage, ChatFunctionCall
           .n(1)
           .temperature(config.getTemperature())
           .topP(config.getTopP())
-          .maxTokens(config.getMaxOutputTokens())
-          .logitBias(new HashMap<>())
-          .build();
+          .logitBias(new HashMap<>());
+      if (config.hasMaxOutputTokens()) {
+        builder.maxTokens(config.getMaxOutputTokens());
+      }
+      ChatCompletionRequest chatCompletionRequest = builder.build();
       AssistantMessage responseMessage;
       try {
         responseMessage = service.createChatCompletion(chatCompletionRequest).getChoices().get(0).getMessage();

--- a/java/acorn-openai/src/main/java/com/datasqrl/ai/models/openai/OpenAiChatProvider.java
+++ b/java/acorn-openai/src/main/java/com/datasqrl/ai/models/openai/OpenAiChatProvider.java
@@ -45,17 +45,19 @@ public class OpenAiChatProvider extends ChatProvider<ChatMessage, ChatFunctionCa
       log.info("Calling OpenAI with model {}", config.getModelName());
       ContextWindow<ChatMessage> contextWindow = session.getContextWindow();
       log.debug("Calling OpenAI with messages: {}", contextWindow.getMessages());
-      ChatCompletionRequest chatCompletionRequest = ChatCompletionRequest
+      ChatCompletionRequest.ChatCompletionRequestBuilder builder = ChatCompletionRequest
           .builder()
           .model(config.getModelName())
           .messages(contextWindow.getMessages())
           .functions(contextWindow.getFunctions())
           .n(1)
-          .topP(config.getTopP())
           .temperature(config.getTemperature())
-          .maxTokens(config.getMaxOutputTokens())
-          .logitBias(new HashMap<>())
-          .build();
+          .topP(config.getTopP())
+          .logitBias(new HashMap<>());
+      if (config.hasMaxOutputTokens()) {
+        builder.maxTokens(config.getMaxOutputTokens());
+      }
+      ChatCompletionRequest chatCompletionRequest = builder.build();
       AssistantMessage responseMessage = service.createChatCompletion(chatCompletionRequest).getChoices().get(0).getMessage();
       log.debug("Response:\n{}", responseMessage);
       String res = responseMessage.getTextContent();

--- a/java/acorn-vertex/src/main/java/com/datasqrl/ai/models/vertex/VertexChatProvider.java
+++ b/java/acorn-vertex/src/main/java/com/datasqrl/ai/models/vertex/VertexChatProvider.java
@@ -41,13 +41,15 @@ public class VertexChatProvider extends ChatProvider<Content, FunctionCall> {
     super(backend, new VertexModelBindings(config));
     this.systemPrompt = systemPrompt;
     VertexAI vertexAI = new VertexAI(config.getProjectId(), config.getLocation());
-    GenerationConfig generationConfig =
+    GenerationConfig.Builder builder =
         GenerationConfig.newBuilder()
-            .setMaxOutputTokens(config.getMaxOutputTokens())
             .setTemperature(((Double) config.getTemperature()).floatValue())
             .setTopP(((Double) config.getTopP()).floatValue())
-            .setTopK(config.getTopK())
-            .build();
+            .setTopK(config.getTopK());
+    if (config.hasMaxOutputTokens()) {
+      builder.setMaxOutputTokens(config.getMaxOutputTokens());
+    }
+    GenerationConfig generationConfig = builder.build();
     this.chatModel = new GenerativeModel(config.getModelName(), vertexAI)
         .withSystemInstruction(ContentMaker.fromString(systemPrompt))
         .withGenerationConfig(generationConfig)

--- a/java/acorn-vertex/src/main/java/com/datasqrl/ai/models/vertex/VertexModelConfiguration.java
+++ b/java/acorn-vertex/src/main/java/com/datasqrl/ai/models/vertex/VertexModelConfiguration.java
@@ -19,7 +19,6 @@ public class VertexModelConfiguration extends AbstractModelConfiguration {
   public static final String LOCATION_KEY = "location";
   public static final String TOP_K_KEY = "top_k";
   public static final int TOP_K_DEFAULT = 40;
-  public static final int MAX_OUTPUT_TOKENS = 8192;
 
   public VertexModelConfiguration(Configuration configuration) {
     super(configuration);
@@ -35,13 +34,6 @@ public class VertexModelConfiguration extends AbstractModelConfiguration {
   @Override
   protected int getMaxTokensForModel() {
     return modelType.getContextWindowLength();
-  }
-
-  @Override
-  public int getMaxOutputTokens() {
-    if (configuration.containsKey(AbstractModelConfiguration.MAX_OUTPUT_TOKENS_KEY))
-      return configuration.getInt(AbstractModelConfiguration.MAX_OUTPUT_TOKENS_KEY);
-    return MAX_OUTPUT_TOKENS;
   }
 
   @Override


### PR DESCRIPTION
### Max output tokens optional
Different models have different output token limits.
- Meta Llama 3 80B has 2048, out of a total context window of 8192 (25%)
- Google Gemini 1.5 has 8192, out of a total context window of 1M (0,8%)
- OpenAI GPT-4 has 4096, out of a total context window of 128K (3%)
Thus, it is impossible to set up a sensible default that works for all models.

The current default of 30% doesn't work, and it makes the call to the model fail unless the user adds the optional `max_output_tokens`. By not setting this config parameter in the ChatProviders unless specified by the user in the config, we make this parameter truly optional